### PR TITLE
Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: python
+python:
+  - "3.5"
+  - "3.6"
+  - "3.7-dev" # 3.7 development branch
+# command to install dependencies
+install:
+  - pip install -r requirements.txt
+  - python setup.py install
+# command to run tests
+script:
+  - pytest

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 Mango Solutions
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # forcats
 
-Python tools for working with categorical data
+[![Build Status](https://travis-ci.org/MangoTheCat/forcats.svg?branch=master)](https://travis-ci.org/MangoTheCat/forcats)
+
+> Python tools for working with categorical data

--- a/README.md
+++ b/README.md
@@ -3,3 +3,7 @@
 [![Build Status](https://travis-ci.org/MangoTheCat/forcats.svg?branch=master)](https://travis-ci.org/MangoTheCat/forcats)
 
 > Python tools for working with categorical data
+
+## License
+
+MIT 2019 © Mango Solutions

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+black
+flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,3 @@
-black
-flake8
 numpy
 pandas
 pytest
-

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(
     description="Tools for working with categorical data",
     url="http://github.com/MangoTheCat/forcats",
     author="Mango Solutions",
+    zip_safe=False,
     install_requires=["pandas", "numpy"],
     license="MIT",
 )


### PR DESCRIPTION
Adds a travis build. Some things I had to do to get this to work:

* Split dev dependencies, `black` and `flake8` into a separate requirements file (Python 3.5 didn't like them in Travis)
* Add `zip_safe=False` into setup.py. `True` would work too if it's something people care about.

There may be some fancier ways to use setup tools to control dev/test dependencies but for now I propose this and someone who is opinionated enough can PR a more elegant build. For now this one is green ✅

Lots of little commits, please **squash and merge**